### PR TITLE
Add volunteer API and React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # HelpingCircle
+
+A simple demo application connecting volunteers with opportunities.
+
+## Backend
+
+The backend is a FastAPI application located in `backend/app/main.py`.
+
+### Setup
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+## Frontend
+
+The frontend is a small React application in the `frontend` folder.
+
+### Setup
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+The webpack dev server proxies API requests to the backend running on port 8000.
+
+## Tests
+
+Run backend tests with:
+
+```bash
+cd backend
+pytest
+```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,64 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List, Dict
+
+app = FastAPI()
+
+class Volunteer(BaseModel):
+    id: int
+    name: str
+    zipcode: str
+    skills: List[str] = []
+
+class Opportunity(BaseModel):
+    id: int
+    name: str
+    zipcode: str
+    skills: List[str] = []
+
+volunteers: Dict[int, Volunteer] = {}
+opportunities: Dict[int, Opportunity] = {}
+donations_by_zip: Dict[str, float] = {}
+donations_by_opportunity: Dict[int, float] = {}
+
+@app.get("/volunteers", response_model=List[Volunteer])
+def list_volunteers():
+    return list(volunteers.values())
+
+@app.post("/volunteers", response_model=Volunteer)
+def create_volunteer(v: Volunteer):
+    if v.id in volunteers:
+        raise HTTPException(status_code=400, detail="Volunteer exists")
+    volunteers[v.id] = v
+    return v
+
+@app.get("/opportunities", response_model=List[Opportunity])
+def list_opportunities():
+    return list(opportunities.values())
+
+@app.post("/opportunities", response_model=Opportunity)
+def create_opportunity(o: Opportunity):
+    if o.id in opportunities:
+        raise HTTPException(status_code=400, detail="Opportunity exists")
+    opportunities[o.id] = o
+    return o
+
+class CommunityDonation(BaseModel):
+    zipcode: str
+    amount: float
+
+class OpportunityDonation(BaseModel):
+    opportunity_id: int
+    amount: float
+
+@app.post("/donate/community")
+def donate_to_community(d: CommunityDonation):
+    donations_by_zip[d.zipcode] = donations_by_zip.get(d.zipcode, 0) + d.amount
+    return {"zipcode": d.zipcode, "total": donations_by_zip[d.zipcode]}
+
+@app.post("/donate/opportunity")
+def donate_to_opportunity(d: OpportunityDonation):
+    if d.opportunity_id not in opportunities:
+        raise HTTPException(status_code=404, detail="Opportunity not found")
+    donations_by_opportunity[d.opportunity_id] = donations_by_opportunity.get(d.opportunity_id, 0) + d.amount
+    return {"opportunity_id": d.opportunity_id, "total": donations_by_opportunity[d.opportunity_id]}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pydantic
+httpx

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_create_and_list_volunteer():
+    response = client.post('/volunteers', json={'id': 1, 'name': 'Alice', 'zipcode': '12345', 'skills': ['cooking']})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['name'] == 'Alice'
+
+    response = client.get('/volunteers')
+    assert response.status_code == 200
+    volunteers = response.json()
+    assert len(volunteers) == 1
+
+
+def test_donate_opportunity():
+    client.post('/opportunities', json={'id': 1, 'name': 'Park Cleanup', 'zipcode': '12345', 'skills': ['cleaning']})
+    response = client.post('/donate/opportunity', json={'opportunity_id': 1, 'amount': 50})
+    assert response.status_code == 200
+    assert response.json()['total'] == 50

--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "helpingcircle-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>HelpingCircle</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="../dist/bundle.js"></script>
+  </body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,75 @@
+import React, { useState, useEffect } from 'react';
+
+export default function App() {
+  const [volunteers, setVolunteers] = useState([]);
+  const [opportunities, setOpportunities] = useState([]);
+  const [name, setName] = useState('');
+  const [skills, setSkills] = useState('');
+  const [opName, setOpName] = useState('');
+  const [opSkills, setOpSkills] = useState('');
+  const [zipcode, setZipcode] = useState('');
+  const [donationAmount, setDonationAmount] = useState('');
+
+  useEffect(() => {
+    fetch('/volunteers').then(r => r.json()).then(setVolunteers);
+    fetch('/opportunities').then(r => r.json()).then(setOpportunities);
+  }, []);
+
+  function addVolunteer() {
+    fetch('/volunteers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: Date.now(), name, zipcode, skills: skills.split(',') })
+    }).then(r => r.json()).then(v => setVolunteers([...volunteers, v]));
+  }
+
+  function addOpportunity() {
+    fetch('/opportunities', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: Date.now(), name: opName, zipcode, skills: opSkills.split(',') })
+    }).then(r => r.json()).then(o => setOpportunities([...opportunities, o]));
+  }
+
+  function donateCommunity() {
+    fetch('/donate/community', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ zipcode, amount: parseFloat(donationAmount) })
+    });
+  }
+
+  return (
+    <div>
+      <h1>HelpingCircle</h1>
+      <div>
+        <h2>Add Volunteer</h2>
+        <input placeholder="Name" value={name} onChange={e => setName(e.target.value)} />
+        <input placeholder="Zipcode" value={zipcode} onChange={e => setZipcode(e.target.value)} />
+        <input placeholder="Skills comma separated" value={skills} onChange={e => setSkills(e.target.value)} />
+        <button onClick={addVolunteer}>Add Volunteer</button>
+      </div>
+      <div>
+        <h2>Add Opportunity</h2>
+        <input placeholder="Name" value={opName} onChange={e => setOpName(e.target.value)} />
+        <input placeholder="Zipcode" value={zipcode} onChange={e => setZipcode(e.target.value)} />
+        <input placeholder="Skills comma separated" value={opSkills} onChange={e => setOpSkills(e.target.value)} />
+        <button onClick={addOpportunity}>Add Opportunity</button>
+      </div>
+      <div>
+        <h2>Donate to Community</h2>
+        <input placeholder="Zipcode" value={zipcode} onChange={e => setZipcode(e.target.value)} />
+        <input placeholder="Amount" value={donationAmount} onChange={e => setDonationAmount(e.target.value)} />
+        <button onClick={donateCommunity}>Donate</button>
+      </div>
+      <h2>Volunteers</h2>
+      <ul>
+        {volunteers.map(v => <li key={v.id}>{v.name} - {v.skills.join(', ')}</li>)}
+      </ul>
+      <h2>Opportunities</h2>
+      <ul>
+        {opportunities.map(o => <li key={o.id}>{o.name} - {o.skills.join(', ')}</li>)}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,18 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [{ test: /\.js$/, exclude: /node_modules/, use: 'babel-loader' }]
+  },
+  devServer: {
+    static: './public',
+    proxy: {
+      '/': 'http://localhost:8000'
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- implement FastAPI back-end with in-memory storage
- add simple React app for volunteers and opportunities
- document setup for both components
- add minimal backend tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685eed860214832d882feeb370afd12d